### PR TITLE
Hotfix Portfolio Links

### DIFF
--- a/routes/portfolio.js
+++ b/routes/portfolio.js
@@ -7,16 +7,18 @@ router.get('/', (req, res, next) => {
 
     getProjects()
         .then(projects => {
+            console.log(projects);
             let proj = projects.map(obj => {
                 return ({
                     name: obj.name,
                     note: obj.note || '',
                     desc: obj.description,
-                    url: obj.links ? obj.links.split(',') : '',
-                    img: obj.images ? obj.images.split(',') : '',
-                    tech: obj.tech ? obj.tech.split(/[^a-zA-Z1-9().]/).filter(i => i) : ''
+                    url: obj.links.split(/[^a-zA-Z1-9\-:\/.]/).filter(i => i !== 'null' ? i : ''),
+                    img: obj.images.split(/[^a-zA-Z1-9\-.]/).filter(i => i !== 'null' ? i : ''),
+                    tech: obj.tech.split(/[^a-zA-Z1-9().]/).filter(i => i !== 'null' ? i : '')
                 });
             });
+            console.log(proj);
 
             context.projects = proj;
             context.page = 'portfolio';

--- a/views/portfolio.pug
+++ b/views/portfolio.pug
@@ -33,4 +33,4 @@ block content
                                 h3 Concept
                                 | !{project.desc}
                                 each addr in project.url
-                                    p: a(href=`${addr}`) #{addr.indexOf('github') !== -1 ? 'View on Github' : 'View Site'}
+                                    p: a(href=`${addr}` target="_blank") #{addr.indexOf('github') !== -1 ? 'View on Github' : 'View Site'}


### PR DESCRIPTION
Links pulled from the database were not being displayed properly.  Processed the output of the DB correctly, handling null strings.  Links also now properly open a new tab.